### PR TITLE
Remove the arithmetic operator on checking download status

### DIFF
--- a/za-patch-dl-handler
+++ b/za-patch-dl-handler
@@ -75,8 +75,8 @@ if [[ -n ${ICE[dl]} && ${ICE[dl]} != ink=[-/[:alnum:]]* ]]; then
 
     local ret=0
 
-    if (( !.zinit-annex-patch-dl-download-file-stdout "${srcdst[1]}" >! "$tdir/$tl" )); then
-      if (( !.zinit-annex-patch-dl-download-file-stdout "${srcdst[1]}" 1 >! "$tdir/$tl" )); then
+    if ! .zinit-annex-patch-dl-download-file-stdout "${srcdst[1]}" >! "$tdir/$tl"; then
+      if ! .zinit-annex-patch-dl-download-file-stdout "${srcdst[1]}" 1 >! "$tdir/$tl"; then
         print -P -- "%F{38}[patch-dl annex]: %F{160}Failed to download the URL %F{220}${srcdst[1]}%f"
         ret=1
       fi


### PR DESCRIPTION
In an attempt to use `if/then` instead of `||` stuff in ZSH an error was made. `(( ... ))` is for arithmetic and when checking the output of a command this leads to a `bad floating point constant` error. This, I believe, is due to `zsh` interpreting the function `.zinit-annex-patch-dl-download-file-stdout` as a float because of the leading `.`.
See [ZSH Arithmetic Evaluation](https://zsh.sourceforge.io/Doc/Release/Arithmetic-Evaluation.html) for more information on this.
The line of interest states:
> Floating point constants are recognized by the presence of a decimal point or an exponent.

## Description
Remove the `(( ... ))`.

## Motivation and Context
Example output with the `(( ... ))`

See the following output:
```zsh
Package: fzf. Selected profile: bgn-binary+keys. Available profiles: bgn, bgn+keys, bgn-binary, bgn-binary+keys, binary, binary+keys, default, default+keys.

Downloading (pack'') junegunn/fzf… (at label: fzf…)
(Requesting `fzf-0.31.0-linux_amd64.tar.gz'…)
######################################################################## 100.0%
ziextract: Unpacking the files from: `fzf-0.31.0-linux_amd64.tar.gz'…
ziextract: Successfully extracted and assigned +x chmod to the file: `fzf'.
za-patch-dl-handler:78: bad floating point constant
[patch-dl annex]: File _fzf_completion downloaded correctly
za-patch-dl-handler:78: bad floating point constant
[patch-dl annex]: File key-bindings.zsh downloaded correctly
za-patch-dl-handler:78: bad floating point constant
[patch-dl annex]: File fzf-tmux.1 downloaded correctly
za-patch-dl-handler:78: bad floating point constant
[patch-dl annex]: File fzf.1 downloaded correctly
bin-gem-node annex: Created the fzf shim and set +x on the fzf binary
```
The result is that each of those files failed to download(really failed to be written to disk) and then when those files are requested later they don't exist.


## Related Issue(s)

## Usage examples <!--- Provide examples of intended usage -->

```zsh
zinit light-mode for \
  zdharma-continuum/zinit-annex-meta-plugins \
  annexes \
  ;

zinit for \
  pack"bgn-binary+keys" fzf zdharma-continuum/null \
  ;
```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->
```zsh
zinit light-mode for \
  zdharma-continuum/zinit-annex-meta-plugins \
  annexes \
  ;

zinit for \
  pack"bgn-binary+keys" fzf zdharma-continuum/null \
  ;
```
Output of the load should have no errors. Also, when a new shell is loaded there should be no errors about not being able to find the `key-bindings.zsh` file.

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
