### PR TITLE
Register the atpull hock to run *after* the actual pull/download

### DIFF
--- a/z-a-patch-dl.plugin.zsh
+++ b/z-a-patch-dl.plugin.zsh
@@ -17,11 +17,11 @@ za-patch-dl-help-null-handler() { :; }
   hook:\!atclone-20 \
   za-patch-dl-handler \
   za-patch-dl-help-null-handler \
-  "dl''|patch''" # register a new ice-mod: test''
+  "dl''|patch''"
 
 # Register !atpull hook
 @zinit-register-annex "zinit-annex-patch-dl" \
-  hook:\!atpull-20 \
+  hook:atpull-20 \
   za-patch-dl-handler \
   za-patch-dl-help-null-handler
 


### PR DESCRIPTION
This prevents a problem when using dl ice without atpull'%atclone'

See https://github.com/zdharma-continuum/zinit/issues/467#issuecomment-1436045853 for a debugging session re this problem.

Complete session:

`.zshrc`:
```
zinit light-mode depth"1" for \
  @zdharma-continuum/zinit-annex-binary-symlink \
  @zdharma-continuum/zinit-annex-bin-gem-node \
  @zdharma-continuum/zinit-annex-default-ice \
  @zdharma-continuum/zinit-annex-patch-dl \
  @zdharma-continuum/zinit-annex-readurl

zinit default-ice --quiet as'null' from"gh-r" lbin'!' lucid nocompile completions

zinit lbin'!' completions \
    dl'https://raw.githubusercontent.com/junegunn/fzf/master/bin/fzf-tmux;
       https://raw.githubusercontent.com/junegunn/fzf/master/shell/completion.zsh -> _fzf_completion;
       https://raw.githubusercontent.com/junegunn/fzf/master/shell/key-bindings.zsh;
       https://raw.githubusercontent.com/junegunn/fzf/master/man/man1/fzf-tmux.1 -> $ZPFX/man/man1/fzf-tmux.1;
       https://raw.githubusercontent.com/junegunn/fzf/master/man/man1/fzf.1 -> $ZPFX/man/man1/fzf.1' \
    src"key-bindings.zsh" \
    for @junegunn/fzf
```

Session:

```
[18:40:00] λ  zinit delete -y junegunn/fzf && exec zsh
linkbin annex: Removed fzf soft link
==> Action executed (exit code: 0)

Downloading junegunn/fzf…
(Requesting `fzf-0.38.0-darwin_amd64.zip'…)
########################################################################################################################################################################### 100.0%
[ziextract] Unpacking the files from: `fzf-0.38.0-darwin_amd64.zip'…
Archive:  fzf-0.38.0-darwin_amd64.zip
  inflating: fzf
[ziextract] Successfully extracted and assigned +x chmod to the file: fzf.
[patch-dl annex] fzf-tmux downloaded successfully
[patch-dl annex] _fzf_completion downloaded successfully
[patch-dl annex] key-bindings.zsh downloaded successfully
[patch-dl annex] fzf-tmux.1 downloaded successfully
[patch-dl annex] fzf.1 downloaded successfully
[linkbin annex] Created the fzf soft link and set +x on the fzf binary
Installed 0 completions. They are stored in the $INSTALLED_COMPS array.
Skipped installing 1 completions. They are stored in the $SKIPPED_COMPS array.

[18:40:10] λ  rm ~/.local/share/zinit/plugins/junegunn---fzf/._zinit/is_release  && zinit update junegunn/fzf
(Requesting `fzf-0.38.0-darwin_amd64.zip', version 0.38.0…)
########################################################################################################################################################################### 100.0%
[ziextract] Unpacking the files from: `fzf-0.38.0-darwin_amd64.zip'…
Archive:  fzf-0.38.0-darwin_amd64.zip
  inflating: fzf
[ziextract] Successfully extracted and assigned +x chmod to the file: fzf.
Installed 0 completions. They are stored in the $INSTALLED_COMPS array.
Skipped installing 1 completions. They are stored in the $SKIPPED_COMPS array.

[patch-dl annex] fzf-tmux downloaded successfully
[patch-dl annex] _fzf_completion downloaded successfully
[patch-dl annex] key-bindings.zsh downloaded successfully
[patch-dl annex] fzf-tmux.1 downloaded successfully
[patch-dl annex] fzf.1 downloaded successfully
[linkbin annex] Re-created the fzf soft link and set +x on the fzf binary
```